### PR TITLE
Update Eclipse.patch

### DIFF
--- a/templates/Eclipse.patch
+++ b/templates/Eclipse.patch
@@ -1,10 +1,2 @@
-# Eclipse Core
-.project
-
-# JDT-specific (Eclipse Java Development Tools)
-.classpath
-
-# Annotation Processing
-.apt_generated
-
+# Spring Boot Tooling
 .sts4-cache/


### PR DESCRIPTION
Remove wrong entries. 

* `.project` and `.classpath` are needed (see https://github.com/github/gitignore/commit/0674ff5b5c77935cbb2ea2269c001bfd84aa1aa5#diff-d8f27c2a874cffb1caf3e38c5cc6a09e)
* `.apt_generated` is already in main file

# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [x] Patch - Template extending functionality of existing template

### Update

- [ ] Template - Update existing `.gitignore` template

## Details

"Make sure that the `.project` and `.classpath` files are under version control. These files must be stored in the repository so that other users checking out the projects for the first time will get the correct type of project and will get the correct Java build path." - https://wiki.eclipse.org/FAQ_How_do_I_set_up_a_Java_project_to_share_in_a_repository%3F

These files are eg generated by Eclipse Maven plugin, so they should be ignored by Maven .gitignore - as proposed by a comment to https://github.com/github/gitignore/commit/0674ff5b5c77935cbb2ea2269c001bfd84aa1aa5#diff-d8f27c2a874cffb1caf3e38c5cc6a09e